### PR TITLE
fix: standardize version management and project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/peterrosemann/biorythm"
-Repository = "https://github.com/peterrosemann/biorythm"
-Issues = "https://github.com/peterrosemann/biorythm/issues"
+Homepage = "https://github.com/dkdndes/pybiorythm"
+Repository = "https://github.com/dkdndes/pybiorythm"
+Issues = "https://github.com/dkdndes/pybiorythm/issues"
 
 [dependency-groups]
 dev = [
@@ -78,10 +78,6 @@ tag-pattern = "v(?P<version>.*)"
 # Version is available via importlib.metadata
 
 [tool.semantic_release]
-version_toml = ["pyproject.toml:project.version"]
-version_variables = [
-    "biorythm/__init__.py:__version__",
-]
 build_command = "uv run python -m build"
 dist_path = "dist/"
 upload_to_vcs_release = true
@@ -126,8 +122,3 @@ ignore_token_for_push = false
 dist_glob_patterns = ["dist/*"]
 upload_to_vcs_release = true
 
-[tool.ruff]
-extend-exclude = ["_version.py"]
-
-[tool.ruff.format]
-exclude = ["_version.py"]


### PR DESCRIPTION
## Summary
- Remove conflicting semantic-release version_toml and version_variables that interfere with hatchling dynamic versioning
- Update repository URLs to correct dkdndes/pybiorythm location
- Clean up outdated _version.py exclusions from ruff configuration
- Standardize to v2.0.0 as current consistent version across project

## Version Consistency Fixes
- **Git tags**: Recreated v2.0.0 to point to latest commit
- **Python package**: Now properly uses hatchling dynamic versioning (shows 2.0.1.dev0+gdcb68f3.d20250808)
- **Semantic-release**: Removed conflicting manual version management
- **Project URLs**: Updated to point to correct repository

## Test Plan
- [x] Verify Python package version detection works
- [x] Confirm git tags are properly ordered
- [x] Validate hatchling dynamic versioning
- [x] Test package build produces correct version