### PR TITLE
fix: correct JSON syntax error in commit-lint configuration

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -61,7 +61,7 @@ jobs:
             "scope-case": [2, "always", "lower-case"],
             "body-leading-blank": [1, "always"],
             "footer-leading-blank": [1, "always"]
-          },
+          }
         }
         EOF
 


### PR DESCRIPTION
Fix JSON syntax error in commit-lint workflow that was causing parse failures.

Remove trailing comma after rules section to create valid JSON configuration.