### PR TITLE
feat: add semantic-release changelog templates

### DIFF
--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+{% for version, release in context.history.unreleased_history.items() %}
+## [Unreleased]
+{% for section, commits in release.items() %}
+{% if commits %}
+
+### {{ section | title }}
+{% for commit in commits %}
+- {{ commit.commit.message | truncate }} ([{{ commit.commit.hexsha[:7] }}]({{ context.repo_url }}/commit/{{ commit.commit.hexsha }}))
+{%- endfor %}
+{% endif %}
+{%- endfor %}
+{% endfor %}
+
+{% for version, release in context.history.released.items() %}
+## [{{ version.as_tag() }}] - {{ version.committed_date.strftime("%Y-%m-%d") }}
+{% for section, commits in release.items() %}
+{% if commits %}
+
+### {{ section | title }}
+{% for commit in commits %}
+- {{ commit.commit.message | truncate }} ([{{ commit.commit.hexsha[:7] }}]({{ context.repo_url }}/commit/{{ commit.commit.hexsha }}))
+{%- endfor %}
+{% endif %}
+{%- endfor %}
+{% endfor %}
+
+{% if context.history.released %}
+{% set oldest_version = context.history.released | list | last %}
+[Unreleased]: {{ context.repo_url }}/compare/{{ oldest_version.as_tag() }}...HEAD
+{% for version in context.history.released %}
+{% if not loop.last %}
+{% set prev_version = context.history.released[loop.index] %}
+[{{ version.as_tag() }}]: {{ context.repo_url }}/compare/{{ prev_version.as_tag() }}...{{ version.as_tag() }}
+{% else %}
+[{{ version.as_tag() }}]: {{ context.repo_url }}/releases/tag/{{ version.as_tag() }}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/templates/CHANGELOG_BODY.md.j2
+++ b/templates/CHANGELOG_BODY.md.j2
@@ -1,0 +1,9 @@
+{% for section, commits in release.items() %}
+{% if commits %}
+### {{ section | title }}
+{% for commit in commits %}
+- {{ commit.commit.message | truncate }}{% if commit.commit.author %} by @{{ commit.commit.author.login }}{% endif %} ([{{ commit.commit.hexsha[:7] }}]({{ context.repo_url }}/commit/{{ commit.commit.hexsha }}))
+{%- endfor %}
+
+{% endif %}
+{%- endfor %}

--- a/uv.lock
+++ b/uv.lock
@@ -175,6 +175,7 @@ wheels = [
 
 [[package]]
 name = "biorythm"
+version = "2.6.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- Fixes semantic-release changelog generation issue
- Creates missing `templates/` directory with proper Jinja2 templates
- Enables automatic population of CHANGELOG.md with release notes

## Changes
- ✅ Created `templates/CHANGELOG.md.j2` for main changelog formatting
- ✅ Created `templates/CHANGELOG_BODY.md.j2` for release body formatting
- ✅ Templates follow Keep a Changelog format with proper sectioning
- ✅ Includes commit links, author information, and categorized changes

## Problem Solved
Previously, semantic-release was configured to use templates (line 111 in pyproject.toml) but the `templates/` directory didn't exist. This caused CHANGELOG.md to remain empty with only boilerplate content.

## Test Plan
- [x] Verify templates directory exists and contains proper files
- [ ] Test semantic-release generates changelog content after merge
- [ ] Confirm CHANGELOG.md is populated with actual release notes

🤖 Generated with [Claude Code](https://claude.ai/code)