### PR TITLE
feat: add semantic-release changelog templates

### DIFF
--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+{% for version, release in context.history.unreleased_history.items() %}
+## [Unreleased]
+{% for section, commits in release.items() %}
+{% if commits %}
+
+### {{ section | title }}
+{% for commit in commits %}
+- {{ commit.commit.message | truncate }} ([{{ commit.commit.hexsha[:7] }}]({{ context.repo_url }}/commit/{{ commit.commit.hexsha }}))
+{%- endfor %}
+{% endif %}
+{%- endfor %}
+{% endfor %}
+
+{% for version, release in context.history.released.items() %}
+## [{{ version.as_tag() }}] - {{ version.committed_date.strftime("%Y-%m-%d") }}
+{% for section, commits in release.items() %}
+{% if commits %}
+
+### {{ section | title }}
+{% for commit in commits %}
+- {{ commit.commit.message | truncate }} ([{{ commit.commit.hexsha[:7] }}]({{ context.repo_url }}/commit/{{ commit.commit.hexsha }}))
+{%- endfor %}
+{% endif %}
+{%- endfor %}
+{% endfor %}
+
+{% if context.history.released %}
+{% set oldest_version = context.history.released | list | last %}
+[Unreleased]: {{ context.repo_url }}/compare/{{ oldest_version.as_tag() }}...HEAD
+{% for version in context.history.released %}
+{% if not loop.last %}
+{% set prev_version = context.history.released[loop.index] %}
+[{{ version.as_tag() }}]: {{ context.repo_url }}/compare/{{ prev_version.as_tag() }}...{{ version.as_tag() }}
+{% else %}
+[{{ version.as_tag() }}]: {{ context.repo_url }}/releases/tag/{{ version.as_tag() }}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/templates/CHANGELOG_BODY.md.j2
+++ b/templates/CHANGELOG_BODY.md.j2
@@ -1,0 +1,9 @@
+{% for section, commits in release.items() %}
+{% if commits %}
+### {{ section | title }}
+{% for commit in commits %}
+- {{ commit.commit.message | truncate }}{% if commit.commit.author %} by @{{ commit.commit.author.login }}{% endif %} ([{{ commit.commit.hexsha[:7] }}]({{ context.repo_url }}/commit/{{ commit.commit.hexsha }}))
+{%- endfor %}
+
+{% endif %}
+{%- endfor %}

--- a/uv.lock
+++ b/uv.lock
@@ -175,6 +175,7 @@ wheels = [
 
 [[package]]
 name = "biorythm"
+version = "2.6.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
Merge develop branch containing changelog template fixes into main for production release.

## Changes from develop
- ✅ Added semantic-release changelog templates
- ✅ Fixed CHANGELOG.md generation issue
- ✅ Created proper Jinja2 templates for Keep a Changelog format
- ✅ Version bump to 2.6.0

## What This Enables
- Automatic CHANGELOG.md population with release notes
- Properly formatted changelog entries with commit links
- Categorized changes (Features, Bug Fixes, etc.)
- Author attribution and version history

## Expected Behavior After Merge
When this is merged to main, semantic-release should:
1. Generate a new version/tag
2. Create a GitHub release
3. **Populate CHANGELOG.md with actual content** (instead of empty file)
4. Trigger Docker builds and SBOM generation

## Test Plan
- [ ] Verify semantic-release runs successfully
- [ ] Confirm CHANGELOG.md gets populated with release notes
- [ ] Check GitHub release is created with proper notes
- [ ] Validate version tags are correct