### PR TITLE
fix: remove non-existent committed_date attribute from changelog template

### DIFF
--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 {% for version, release in context.history.released.items() %}
-## [{{ version.as_tag() }}] - {{ version.committed_date.strftime("%Y-%m-%d") }}
+## [{{ version.as_tag() }}]
 {% for section, commits in release.items() %}
 {% if commits %}
 


### PR DESCRIPTION
## Summary
Fixes second template error in semantic-release workflow.

## Problem
After fixing the unreleased_history issue, semantic-release now fails with:
```
Error: 'semantic_release.version.version.Version object' has no attribute 'committed_date'
```

## Root Cause
The template was using `version.committed_date` which doesn't exist on the Version object.

## Changes
- ✅ Removed `committed_date.strftime('%Y-%m-%d')` from version header
- ✅ Simplified to just `## [{{ version.as_tag() }}]` format
- ✅ Maintains compatibility with semantic-release objects

## Expected Result
- Semantic-release should now complete successfully
- CHANGELOG.md should be populated with version entries
- Templates should work without attribute errors