### PR TITLE
fix: remove Actor object iteration from changelog body template

### DIFF
--- a/templates/CHANGELOG_BODY.md.j2
+++ b/templates/CHANGELOG_BODY.md.j2
@@ -2,7 +2,7 @@
 {% if commits %}
 ### {{ section | title }}
 {% for commit in commits %}
-- {{ commit.commit.message | truncate }}{% if commit.commit.author %} by @{{ commit.commit.author.login }}{% endif %} ([{{ commit.commit.hexsha[:7] }}]({{ context.repo_url }}/commit/{{ commit.commit.hexsha }}))
+- {{ commit.commit.message.split('\n')[0] }} ([{{ commit.commit.hexsha[:7] }}]({{ context.repo_url }}/commit/{{ commit.commit.hexsha }}))
 {%- endfor %}
 
 {% endif %}


### PR DESCRIPTION
## Summary
Fixes third template error in semantic-release workflow.

## Problem
After fixing the date format issue, semantic-release now fails with:
```
Error: 'Actor' object is not iterable
```

## Root Cause
The CHANGELOG_BODY.md.j2 template was trying to access `commit.commit.author.login` which causes an iteration error on the Actor object.

## Changes
- ✅ Removed `commit.commit.author.login` reference
- ✅ Simplified to show only commit message and hash link
- ✅ Use `split('\n')[0]` instead of `truncate` for consistency
- ✅ Maintains clean changelog format without author attribution errors

## Expected Result
- Semantic-release should now complete successfully on develop
- CHANGELOG.md should be populated with release entries
- Templates should work without object iteration errors